### PR TITLE
Traefik

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ services:
       traefik.http.routers.svn-router-https.rule: Host(`svn.example.com`)
 ```
 
+**Note** the example traefik setup also handles the ssh port.
+
 # How to create SVN Repository ?
 
 First of all generate ssh public key using below command.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ If you don't override the `data-volume` definition, then docker will pick the lo
 (see with `docker volume ls` and `docker volume inspect [volume-name]`). This is generally preferred for
 production, especially on Mac/Windows hosts.
 
+## Traefik
+If you have traefik running on ports 80, and 443, using a configured `docker network` named `traefik-public` AND configured to manage ssl 
+certificates via Let's Encrypt, then you do not need to export port 80 (or 443) in your site specific override. Do override the following
+to configure your domain:
+
+```
+services:
+  web:
+    labels:
+      traefik.http.routers.svn-router-http.rule: Host(`svn.example.com`)
+      traefik.http.routers.svn-router-https.rule: Host(`svn.example.com`)
+```
+
 # How to create SVN Repository ?
 
 First of all generate ssh public key using below command.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,30 @@
 version: "2.0"
 services:
   web:
-    container_name: svn
     image: "botlink/subversion:${UBUNTU_VERSION:-18.04}"
     volumes:
       - data-volume:/var/lib/svn
     networks:
       svn-network: null
+      traefik-public: null
+    labels:
+      traefik.docker.network: traefik-public
+      traefik.enable: "true"
+      traefik.http.routers.svn-router-http.entrypoints: http
+      traefik.http.routers.svn-router-http.middlewares: https-redirect
+      traefik.http.routers.svn-router-http.rule: Host(`svn.example.com`)
+      traefik.http.routers.svn-router-http.service: svn-router
+      traefik.http.routers.svn-router-https.entrypoints: https
+      traefik.http.routers.svn-router-https.rule: Host(`svn.example.com`)
+      traefik.http.routers.svn-router-https.service: svn-router
+      traefik.http.routers.svn-router-https.tls: "true"
+      traefik.http.routers.svn-router-https.tls.certresolver: le
+      traefik.http.services.svn-router.loadbalancer.server.port: "80"
+
 networks:
   svn-network:
+    name: svn-router
+  traefik-public:
+    external: true
 volumes:
   data-volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,10 @@ services:
       traefik.http.routers.svn-router-https.tls: "true"
       traefik.http.routers.svn-router-https.tls.certresolver: le
       traefik.http.services.svn-router.loadbalancer.server.port: "80"
+      traefik.tcp.routers.svn-router-ssh.rule: HostSNI(`*`)
+      traefik.tcp.routers.svn-router-ssh.service: svn-router-ssh
+      traefik.tcp.routers.svn-router-ssh.entrypoints: ssh-svn
+      traefik.tcp.services.svn-router-ssh.loadbalancer.server.port: "22"
 
 networks:
   svn-network:

--- a/traefik/.gitignore
+++ b/traefik/.gitignore
@@ -1,0 +1,1 @@
+traefik.env

--- a/traefik/README.md
+++ b/traefik/README.md
@@ -1,0 +1,38 @@
+# Setup
+Make a traefik.env like:
+```
+echo 'TRAEFIK_DOMAIN=traefik.example.com' > ./traefik.env
+echo 'EMAIL=admin@example.com' >> ./traefik.env
+echo 'HASHED_PASSWORD="'$(openssl passwd -apr1 changeit | sed 's/\$/\\\$/g')'"' >> ./traefik.env
+```
+
+**Note**
+* Change the domain and email address to match what you will be using
+* Change the password from `changeit` to be more secure. This is the password for the `admin` user
+  on traefik's web interface (available at traefik.example.com) 
+
+# Start
+
+```
+$ docker compose --env-file ./traefik.env up -d
+```
+
+# Stop
+
+```
+$ docker compose -p traefik down
+```
+
+## Overrides
+The `docker-compose.yaml` on its own will start traefik for http only and start automatically when docker starts.
+The `docker-compose.override.yaml` includes SSL via LetsEncrypt's HTTP challenge.
+
+If that meets your needs, this is suitable for production. Start traefik before starting your other services
+
+If you wish to use another challenge (such as DNS), review Traefik's documentation and override the `command:` section.
+Since you can't append to `command:`, it's probably best to copy the `docker-compose.override.yaml` and modify it per your needs.
+In that case, start with:
+
+```
+$ docker compose --env-file ./traefik.env -f ./docker-compose.yaml -f ./my-custom-ssl.yaml up -d
+```

--- a/traefik/README.md
+++ b/traefik/README.md
@@ -3,6 +3,7 @@ Make a traefik.env like:
 ```
 echo 'TRAEFIK_DOMAIN=traefik.example.com' > ./traefik.env
 echo 'EMAIL=admin@example.com' >> ./traefik.env
+echo 'SSH_PORT=2022' >> ./traefik.env
 echo 'HASHED_PASSWORD="'$(openssl passwd -apr1 changeit | sed 's/\$/\\\$/g')'"' >> ./traefik.env
 ```
 
@@ -10,6 +11,8 @@ echo 'HASHED_PASSWORD="'$(openssl passwd -apr1 changeit | sed 's/\$/\\\$/g')'"' 
 * Change the domain and email address to match what you will be using
 * Change the password from `changeit` to be more secure. This is the password for the `admin` user
   on traefik's web interface (available at traefik.example.com) 
+* To bind SSH to a specific IP address, include it like `SSH_PORT=192.168.2.100:22`
+  This is useful so you can dedicate a server IP for Subversion's ssh and use the standard SSH port
 
 # Start
 

--- a/traefik/docker-compose.override.yaml
+++ b/traefik/docker-compose.override.yaml
@@ -29,6 +29,8 @@ services:
       - --entrypoints.http.address=:80
       # Create an entrypoint https listening on port 443
       - --entrypoints.https.address=:443
+      # Create an entrypoint with SSH for SVN
+      - --entrypoints.ssh-svn.address=:2022
       # Create the certificate resolver le for Let's Encrypt, uses the environment variable EMAIL
       - --certificatesresolvers.le.acme.email=${EMAIL:?No EMAIL set}
       # Store the Let's Encrypt certificates in the mounted volume

--- a/traefik/docker-compose.override.yaml
+++ b/traefik/docker-compose.override.yaml
@@ -1,0 +1,48 @@
+services:
+  traefik:
+    volumes:
+      - traefik-certs:/certificates
+    labels:
+      # https-redirect middleware to redirect HTTP to HTTPS
+      # It can be re-used by other stacks in other Docker Compose files
+      - traefik.http.middlewares.https-redirect.redirectscheme.scheme=https
+      - traefik.http.middlewares.https-redirect.redirectscheme.permanent=true
+      # traefik-http to use the middleware to redirect to https
+      - traefik.http.routers.traefik-public-http.middlewares=https-redirect
+      # traefik-https the actual router using HTTPS
+      # Uses the environment variable DOMAIN
+      - traefik.http.routers.traefik-public-https.rule=Host(`${TRAEFIK_DOMAIN}`)
+      - traefik.http.routers.traefik-public-https.entrypoints=https
+      - traefik.http.routers.traefik-public-https.tls=true
+      # Use the special Traefik service api@internal with the web UI/Dashboard
+      - traefik.http.routers.traefik-public-https.service=api@internal
+      # Use the "le" (Let's Encrypt) resolver created below
+      - traefik.http.routers.traefik-public-https.tls.certresolver=le
+      # Enable HTTP Basic auth, using the middleware created above
+      - traefik.http.routers.traefik-public-https.middlewares=admin-auth
+    command:
+      # Enable Docker in Traefik, so that it reads labels from Docker services
+      - --providers.docker=true
+      # Do not expose all Docker services, only the ones explicitly exposed
+      - --providers.docker.exposedbydefault=false
+      # Create an entrypoint http listening on port 80
+      - --entrypoints.http.address=:80
+      # Create an entrypoint https listening on port 443
+      - --entrypoints.https.address=:443
+      # Create the certificate resolver le for Let's Encrypt, uses the environment variable EMAIL
+      - --certificatesresolvers.le.acme.email=${EMAIL:?No EMAIL set}
+      # Store the Let's Encrypt certificates in the mounted volume
+      - --certificatesresolvers.le.acme.storage=/certificates/acme.json
+      # Use the TLS Challenge for Let's Encrypt
+      - --certificatesresolvers.le.acme.tlschallenge=true
+      # Enable the access log, with HTTP requests
+      - --accesslog
+      # Enable the Traefik log, for configurations and errors
+      - --log
+      # Enable the Dashboard and API
+      - --api
+    ports:
+      - 443:443
+
+volumes:
+  traefik-certs:

--- a/traefik/docker-compose.yaml
+++ b/traefik/docker-compose.yaml
@@ -20,6 +20,7 @@ services:
       - traefik.http.routers.traefik-public-http.middlewares=admin-auth
       # Define the port inside of the Docker service to use
       - traefik.http.services.traefik-public.loadbalancer.server.port=8080
+
     command:
       # Enable Docker in Traefik, so that it reads labels from Docker services
       - --providers.docker=true
@@ -29,12 +30,15 @@ services:
       - --entrypoints.http.address=:80
       # Enable the access log, with HTTP requests
       - --accesslog
+      # Create an entrypoint with SSH for SVN
+      - --entrypoints.ssh-svn.address=:2022
       # Enable the Traefik log, for configurations and errors
       - --log
       # Enable the Dashboard and API
       - --api
     ports:
       - 80:80
+      - ${SSH_PORT:-2022}:2022
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:

--- a/traefik/docker-compose.yaml
+++ b/traefik/docker-compose.yaml
@@ -1,0 +1,47 @@
+version: "3.3"
+
+services:
+  traefik:
+    image: "traefik:v2.6"
+    labels:
+      # Enable Traefik for this service, to make it available in the public network
+      - traefik.enable=true
+      # Use the traefik-public network (declared below)
+      - traefik.docker.network=traefik-public
+      # admin-auth middleware with HTTP Basic auth
+      # Using the environment variables USERNAME and HASHED_PASSWORD
+      - traefik.http.middlewares.admin-auth.basicauth.users=admin:${HASHED_PASSWORD:?No HASHED_PASSWORD set}
+      # Uses the environment variable TRAEFIK_DOMAIN
+      - traefik.http.routers.traefik-public-http.rule=Host(`${TRAEFIK_DOMAIN:?No TRAEFIK_DOMAIN set}`)
+      - traefik.http.routers.traefik-public-http.entrypoints=http
+      # Use the special Traefik service api@internal with the web UI/Dashboard
+      - traefik.http.routers.traefik-public-http.service=api@internal
+      # Enable HTTP Basic auth, using the middleware created above
+      - traefik.http.routers.traefik-public-http.middlewares=admin-auth
+      # Define the port inside of the Docker service to use
+      - traefik.http.services.traefik-public.loadbalancer.server.port=8080
+    command:
+      # Enable Docker in Traefik, so that it reads labels from Docker services
+      - --providers.docker=true
+      # Do not expose all Docker services, only the ones explicitly exposed
+      - --providers.docker.exposedbydefault=false
+      # Create an entrypoint http listening on port 80
+      - --entrypoints.http.address=:80
+      # Enable the access log, with HTTP requests
+      - --accesslog
+      # Enable the Traefik log, for configurations and errors
+      - --log
+      # Enable the Dashboard and API
+      - --api
+    ports:
+      - 80:80
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - traefik-public
+    restart: always
+
+networks:
+  traefik-public:
+    name: traefik-public
+    external: false


### PR DESCRIPTION
Support for http, https, and ssh ports via traefik. With this, its not necessary to bind any ports directly to the subversion container and only traefik is accessible externally.

closes #2 